### PR TITLE
Fix Call to undefined method BinaryFileResponse::header

### DIFF
--- a/src/Http/Middleware/NoHttpCache.php
+++ b/src/Http/Middleware/NoHttpCache.php
@@ -31,9 +31,9 @@ class NoHttpCache
             $response = new Response($response);
         }
 
-        $response->header('Pragma', 'no-cache')
-                 ->header('Expires', 'Sat, 01-Jan-2000 00:00:00 GMT')
-                 ->header('Cache-Control', 'private, no-store, no-cache, must-revalidate, pre-check=0, post-check=0, max-age=0, s-maxage=0');
+        $response->headers->set('Pragma' , 'no-cache');
+        $response->headers->set('Expires' , 'Sat, 01-Jan-2000 00:00:00 GMT');
+        $response->headers->set('Cache-Control' , 'private, no-store, no-cache, must-revalidate, pre-check=0, post-check=0, max-age=0, s-maxage=0');
 
         return $response;
     }

--- a/src/Http/Middleware/TurbolinksLocation.php
+++ b/src/Http/Middleware/TurbolinksLocation.php
@@ -20,7 +20,7 @@ class TurbolinksLocation
     {
         $response = $next($request);
 
-        $response->header('Turbolinks-Location', $request->fullUrl());
+        $response->headers->set('Turbolinks-Location', $request->fullUrl());
 
         return $response;
     }


### PR DESCRIPTION
When export csv or excel i have got the following exception `Call to undefined method Symfony\Component\HttpFoundation\BinaryFileResponse::header()
` as BinaryFileResponse doesn't have a `header` funcation so we can modify the `headers` property direct