### PR TITLE
use slug instead of name when call firstOrCreate for accessarea

### DIFF
--- a/database/seeders/CortexFoundationSeeder.php
+++ b/database/seeders/CortexFoundationSeeder.php
@@ -56,7 +56,7 @@ class CortexFoundationSeeder extends Seeder
 
         collect($accessareas)->each(function (array $accessarea) {
             app('cortex.foundation.accessarea')->firstOrCreate([
-                'name' => $accessarea['name'],
+                'slug' => $accessarea['slug'],
             ], $accessarea);
         });
     }


### PR DESCRIPTION
since name column at accessareaes table is translatable which mean adminarea will be stored like {'en' : 'adminarea'} so it won't match any record if we search by namw and we must search through slug column.